### PR TITLE
記事ページの画像幅の最大値修正

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -217,6 +217,9 @@ a {
     margin: 20px 0px;
 }
 
+#contents #main img {
+    max-width: 100%;
+}
 
 .pagination li a,
 .pagination li span {
@@ -401,7 +404,7 @@ table td{
  * comment & comment balloon
  ******/
 
-    
+
 div.comment_container {
     border-top:1px solid #CCCCCC;
 }


### PR DESCRIPTION
記事ページで、記事の幅を越える画像を投稿した際のスタイル表示を修正しました。

## 修正前

![](http://i.gyazo.com/8574e4a42cd365106e59dfadead65cc9.png)

## 修正後

![](http://i.gyazo.com/f0d2dc94efe89688c7478737650f14f0.png)